### PR TITLE
fix(scanner): only let ordered lists starting with 1 interrupt a paragraph

### DIFF
--- a/tree-sitter-markdown/src/scanner.c
+++ b/tree-sitter-markdown/src/scanner.c
@@ -735,6 +735,7 @@ static bool parse_ordered_list_marker(Scanner *s, TSLexer *lexer,
          valid_symbols[LIST_MARKER_PARENTHESIS_DONT_INTERRUPT] ||
          valid_symbols[LIST_MARKER_DOT_DONT_INTERRUPT])) {
         size_t digits = 1;
+        // A list may only interrupt a paragraph if it starts with 1.
         bool dont_interrupt = lexer->lookahead != '1';
         advance(s, lexer);
         while (isdigit(lexer->lookahead)) {

--- a/tree-sitter-markdown/src/scanner.c
+++ b/tree-sitter-markdown/src/scanner.c
@@ -735,13 +735,6 @@ static bool parse_ordered_list_marker(Scanner *s, TSLexer *lexer,
          valid_symbols[LIST_MARKER_PARENTHESIS_DONT_INTERRUPT] ||
          valid_symbols[LIST_MARKER_DOT_DONT_INTERRUPT])) {
         size_t digits = 1;
-        // A list may only interrupt a paragraph if it starts with 1. See
-        // https://spec.commonmark.org/0.31.2/#list-items, list items rule 1:
-        // "if the list item is ordered, the start number must be 1".
-        // Note that `lookahead` is always a digit here, since this function is
-        // only reached from the '0'-'9' cases of the dispatch switch in
-        // `scan`, so a check such as `!isdigit(lexer->lookahead)` would be
-        // constant `false` and let every single-digit marker interrupt.
         bool dont_interrupt = lexer->lookahead != '1';
         advance(s, lexer);
         while (isdigit(lexer->lookahead)) {

--- a/tree-sitter-markdown/src/scanner.c
+++ b/tree-sitter-markdown/src/scanner.c
@@ -735,7 +735,13 @@ static bool parse_ordered_list_marker(Scanner *s, TSLexer *lexer,
          valid_symbols[LIST_MARKER_PARENTHESIS_DONT_INTERRUPT] ||
          valid_symbols[LIST_MARKER_DOT_DONT_INTERRUPT])) {
         size_t digits = 1;
-        bool dont_interrupt = !isdigit(lexer->lookahead);
+        // Only a marker whose number is exactly 1 may interrupt a paragraph,
+        // so any other start number implies `dont_interrupt`. See
+        // https://spec.commonmark.org/0.31.2/#list-items, "In order for a
+        // list to interrupt a paragraph [...] it must start with 1."
+        // `lookahead` is always a digit here: this function is only reached
+        // from the '0'-'9' cases of the dispatch switch in `scan`.
+        bool dont_interrupt = lexer->lookahead != '1';
         advance(s, lexer);
         while (isdigit(lexer->lookahead)) {
             dont_interrupt = true;

--- a/tree-sitter-markdown/src/scanner.c
+++ b/tree-sitter-markdown/src/scanner.c
@@ -735,12 +735,13 @@ static bool parse_ordered_list_marker(Scanner *s, TSLexer *lexer,
          valid_symbols[LIST_MARKER_PARENTHESIS_DONT_INTERRUPT] ||
          valid_symbols[LIST_MARKER_DOT_DONT_INTERRUPT])) {
         size_t digits = 1;
-        // Only a marker whose number is exactly 1 may interrupt a paragraph,
-        // so any other start number implies `dont_interrupt`. See
-        // https://spec.commonmark.org/0.31.2/#list-items, "In order for a
-        // list to interrupt a paragraph [...] it must start with 1."
-        // `lookahead` is always a digit here: this function is only reached
-        // from the '0'-'9' cases of the dispatch switch in `scan`.
+        // A list may only interrupt a paragraph if it starts with 1. See
+        // https://spec.commonmark.org/0.31.2/#list-items, list items rule 1:
+        // "if the list item is ordered, the start number must be 1".
+        // Note that `lookahead` is always a digit here, since this function is
+        // only reached from the '0'-'9' cases of the dispatch switch in
+        // `scan`, so a check such as `!isdigit(lexer->lookahead)` would be
+        // constant `false` and let every single-digit marker interrupt.
         bool dont_interrupt = lexer->lookahead != '1';
         advance(s, lexer);
         while (isdigit(lexer->lookahead)) {

--- a/tree-sitter-markdown/test/corpus/issues.txt
+++ b/tree-sitter-markdown/test/corpus/issues.txt
@@ -237,3 +237,45 @@ A paragraph,
       (inline))
     (paragraph
       (inline))))
+
+================================================================================
+#257 - Non-1 nested ordered markers do not interrupt list-item paragraphs
+================================================================================
+
+* List item
+    0) Zero
+    1) One
+    2) Two
+
+* Backwards list
+    9) Nine
+    8) Eight
+
+--------------------------------------------------------------------------------
+
+(document
+  (section
+    (list
+      (list_item
+        (list_marker_star)
+        (paragraph
+          (inline
+            (block_continuation))
+          (block_continuation))
+        (list
+          (list_item
+            (list_marker_parenthesis)
+            (paragraph
+              (inline)
+              (block_continuation)))
+          (list_item
+            (list_marker_parenthesis)
+            (paragraph
+              (inline)
+              (block_continuation)))))
+      (list_item
+        (list_marker_star)
+        (paragraph
+          (inline
+            (block_continuation)
+            (block_continuation)))))))

--- a/tree-sitter-markdown/test/corpus/issues.txt
+++ b/tree-sitter-markdown/test/corpus/issues.txt
@@ -116,15 +116,51 @@ globalNS.method1(5, 10);
       (inline))))
 
 ================================================================================
-#226 (PR) - Allow ordered lists to start from any number
+#226 (PR) - Ordered lists can start from any number
+================================================================================
+
+2) Two
+3) Three
+
+7. Seven
+8. Eight
+
+--------------------------------------------------------------------------------
+
+(document
+  (section
+    (list
+      (list_item
+        (list_marker_parenthesis)
+        (paragraph
+          (inline)))
+      (list_item
+        (list_marker_parenthesis)
+        (paragraph
+          (inline)
+          (block_continuation))))
+    (list
+      (list_item
+        (list_marker_dot)
+        (paragraph
+          (inline)))
+      (list_item
+        (list_marker_dot)
+        (paragraph
+          (inline))))))
+
+================================================================================
+#226 (PR) - Nested ordered lists can start from any number
 ================================================================================
 
 * List item
+
     0) Zero
     1) One
     2) Two
 
 * Backwards list
+
     9) Nine
     8) Eight
 
@@ -138,6 +174,7 @@ globalNS.method1(5, 10);
         (paragraph
           (inline)
           (block_continuation))
+        (block_continuation)
         (list
           (list_item
             (list_marker_parenthesis)
@@ -159,6 +196,7 @@ globalNS.method1(5, 10);
         (paragraph
           (inline)
           (block_continuation))
+        (block_continuation)
         (list
           (list_item
             (list_marker_parenthesis)
@@ -169,3 +207,33 @@ globalNS.method1(5, 10);
             (list_marker_parenthesis)
             (paragraph
               (inline))))))))
+
+================================================================================
+#257 - Only an ordered list starting with 1 may interrupt a paragraph
+================================================================================
+
+A paragraph,
+1. and a list interrupting it.
+
+A paragraph,
+2. not a list.
+
+A paragraph,
+10. not a list either.
+
+--------------------------------------------------------------------------------
+
+(document
+  (section
+    (paragraph
+      (inline))
+    (list
+      (list_item
+        (list_marker_dot)
+        (paragraph
+          (inline)
+          (block_continuation))))
+    (paragraph
+      (inline))
+    (paragraph
+      (inline))))


### PR DESCRIPTION
Ordered markers other than `1` currently interrupt paragraphs because `!isdigit(lexer->lookahead)` is always false at this call site.

Restore the `lookahead != '1'` check required by CommonMark while preserving non-1 ordered lists where lists are valid. Update the #226 tests to distinguish valid list starts from paragraph interruption, and add #257 regression coverage.

Fixes #257.

<sub><em><img src="https://raw.githubusercontent.com/tclem/dotfiles/main/copilot/assets/copilot-signature.svg" alt="" align="absmiddle" style="display: inline;">&nbsp;&nbsp;Generated via Copilot (GPT-5.6 Sol) <a href="https://adaptivepatchwork.com/ai-attribution/">on behalf</a> of @tclem</em></sub>